### PR TITLE
Fix blog CMS sync paths

### DIFF
--- a/.github/workflows/pages-cms-sync.yml
+++ b/.github/workflows/pages-cms-sync.yml
@@ -41,5 +41,6 @@ jobs:
           commit_user_email: actions@github.com
           skip_dirty_check: false
           file_pattern: |
-            blog/**/*.html
-            blog/blog-index.json
+            content/posts/**/*.html
+            content/blog-index.json
+            content/index.html

--- a/assets/js/blog-dynamic-load.js
+++ b/assets/js/blog-dynamic-load.js
@@ -8,8 +8,9 @@
     
     // Configuration
     const CONFIG = {
-        indexPath: 'content/blog-index.json',
-        blogPath: 'content/posts/',
+        // Use absolute paths so the blog works whether it's served from /blog or /blog/index.html
+        indexPath: '/content/blog-index.json',
+        blogPath: '/content/posts/',
         postsPerPage: 9,
         gridSelector: '#blog-posts-grid'
     };


### PR DESCRIPTION
## Summary
- ensure the blog loader requests CMS JSON and post pages from absolute paths so the blog works from any route
- update the Pages CMS workflow to commit the generated content under the content/ directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e418abb4948321b7a348c968159a06